### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Minimal Android offline Warehouse Management System
 
 Main functionalities:
--importing excell and csv orders
+-importing Excel and csv orders
 -pickup order assistant
 


### PR DESCRIPTION
## Summary
- correct the spelling for Excel in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68403358bf88832991666009c4dd0cfc